### PR TITLE
Key generation form updates based on user testing

### DIFF
--- a/src/tumpa/GenerateKeyView.qml
+++ b/src/tumpa/GenerateKeyView.qml
@@ -24,12 +24,12 @@ Rectangle {
     ListModel {
         id: keyAlgoOptions
         ListElement {
-            text: "RSA 4096"
-            value: "rsa4096"
-        }
-        ListElement {
             text: "Curve 25519"
             value: "curve25519"
+        }
+        ListElement {
+            text: "RSA 4096"
+            value: "rsa4096"
         }
     }
 

--- a/src/tumpa/includes/Forms/DropdownInputField.qml
+++ b/src/tumpa/includes/Forms/DropdownInputField.qml
@@ -33,8 +33,18 @@ Item {
             top: label.bottom
             topMargin: 14
         }
-        leftPadding: 10
-        rightPadding: 10
+        font.pixelSize: 14
+
+        contentItem: Text {
+            leftPadding: 10
+            rightPadding: 10
+
+            text: control.displayText
+            font: control.font
+            color: "#111827"
+            verticalAlignment: Text.AlignVCenter
+            elide: Text.ElideRight
+        }
 
         background: Rectangle {
             id: backgroundRect

--- a/src/tumpa/includes/Forms/TextInputField.qml
+++ b/src/tumpa/includes/Forms/TextInputField.qml
@@ -36,6 +36,7 @@ Item {
         leftPadding: 10
         rightPadding: 10
         verticalAlignment: TextInput.AlignVCenter
+        color: "#111827"
 
         background: Rectangle {
             color: "transparent"

--- a/src/tumpa/includes/Forms/TextareaInputField.qml
+++ b/src/tumpa/includes/Forms/TextareaInputField.qml
@@ -36,6 +36,7 @@ Item {
             rightPadding: 10
             topPadding: 6
             bottomPadding: 6
+            color: "#111827"
 
             background: Rectangle {
                 color: "transparent"


### PR DESCRIPTION
In dark mode, the text inputted in the forms had a lighter color. This was because we never explicitly mentioned the color. Since we don't have dark mode support right now, I have explicitly mentioned the colors of the input in this PR.

Also, based on user testing, I have made curve 25519 as the default algorithm for key generation in the form instead of RSA 4096